### PR TITLE
Added a lifecycle on aws_guardduty_member to ignore email changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Terraform Aws Guardduty Organization Module
 Terraform module to setup AWS GuardDuty in an organization
 
@@ -73,7 +72,7 @@ module "guardduty" {
 | <a name="input_enable_eks_runtime_monitoring"></a> [enable\_eks\_runtime\_monitoring](#input\_enable\_eks\_runtime\_monitoring) | (Optional) If true, enables EKS GuardDuty Add-on for EKS protection. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_enable_runtime_protection"></a> [enable\_runtime\_protection](#input\_enable\_runtime\_protection) | (Optional) If true, enables Runtime monitoring for EKS and ECS. Conflicts with `enable_eks_runtime_monitoring` Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_finding_publishing_frequency"></a> [finding\_publishing\_frequency](#input\_finding\_publishing\_frequency) | (Optional) Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty primary account and cannot be modified, otherwise defaults to SIX\_HOURS. For standalone and GuardDuty primary accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and primary accounts: FIFTEEN\_MINUTES, ONE\_HOUR, SIX\_HOURS. Defaults to `SIX_HOURS`. | `string` | `"SIX_HOURS"` | no |
-| <a name="input_members"></a> [members](#input\_members) | List of member accounts to invite to GuardDuty | <pre>map(object({<br/>    account_id = string<br/>    email      = string<br/>  }))</pre> | `{}` | no |
+| <a name="input_members"></a> [members](#input\_members) | List of member accounts to invite to GuardDuty | <pre>map(object({<br>    account_id = string<br>    email      = string<br>  }))</pre> | `{}` | no |
 | <a name="input_publish_destination_kms_key_arn"></a> [publish\_destination\_kms\_key\_arn](#input\_publish\_destination\_kms\_key\_arn) | (Optional) The ARN of the KMS key used to encrypt GuardDuty findings. GuardDuty enforces this to be encrypted. | `string` | `""` | no |
 | <a name="input_publish_destination_s3_arn"></a> [publish\_destination\_s3\_arn](#input\_publish\_destination\_s3\_arn) | (Optional) The bucket arn and prefix under which the findings get exported. Bucket-ARN is required, the prefix is optional and will be `AWSLogs/[Account-ID]/GuardDuty/[Region]/` if not provided. | `string` | `""` | no |
 | <a name="input_scan_eks_audit_logs"></a> [scan\_eks\_audit\_logs](#input\_scan\_eks\_audit\_logs) | (Optional) If true, enables Kubernetes audit logs as a data source for Kubernetes protection. Defaults to `true`. | `bool` | `true` | no |
@@ -95,4 +94,3 @@ Checkout our other :point\_right: [terraform modules](https://registry.terraform
 ## Copyright
 
 Copyright © 2017-2025 [Blackbird Cloud](https://blackbird.cloud)
-<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- BEGIN_TF_DOCS -->
 # Terraform Aws Guardduty Organization Module
 Terraform module to setup AWS GuardDuty in an organization
 
@@ -72,7 +73,7 @@ module "guardduty" {
 | <a name="input_enable_eks_runtime_monitoring"></a> [enable\_eks\_runtime\_monitoring](#input\_enable\_eks\_runtime\_monitoring) | (Optional) If true, enables EKS GuardDuty Add-on for EKS protection. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_enable_runtime_protection"></a> [enable\_runtime\_protection](#input\_enable\_runtime\_protection) | (Optional) If true, enables Runtime monitoring for EKS and ECS. Conflicts with `enable_eks_runtime_monitoring` Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_finding_publishing_frequency"></a> [finding\_publishing\_frequency](#input\_finding\_publishing\_frequency) | (Optional) Specifies the frequency of notifications sent for subsequent finding occurrences. If the detector is a GuardDuty member account, the value is determined by the GuardDuty primary account and cannot be modified, otherwise defaults to SIX\_HOURS. For standalone and GuardDuty primary accounts, it must be configured in Terraform to enable drift detection. Valid values for standalone and primary accounts: FIFTEEN\_MINUTES, ONE\_HOUR, SIX\_HOURS. Defaults to `SIX_HOURS`. | `string` | `"SIX_HOURS"` | no |
-| <a name="input_members"></a> [members](#input\_members) | List of member accounts to invite to GuardDuty | <pre>map(object({<br>    account_id = string<br>    email      = string<br>  }))</pre> | `{}` | no |
+| <a name="input_members"></a> [members](#input\_members) | List of member accounts to invite to GuardDuty | <pre>map(object({<br/>    account_id = string<br/>    email      = string<br/>  }))</pre> | `{}` | no |
 | <a name="input_publish_destination_kms_key_arn"></a> [publish\_destination\_kms\_key\_arn](#input\_publish\_destination\_kms\_key\_arn) | (Optional) The ARN of the KMS key used to encrypt GuardDuty findings. GuardDuty enforces this to be encrypted. | `string` | `""` | no |
 | <a name="input_publish_destination_s3_arn"></a> [publish\_destination\_s3\_arn](#input\_publish\_destination\_s3\_arn) | (Optional) The bucket arn and prefix under which the findings get exported. Bucket-ARN is required, the prefix is optional and will be `AWSLogs/[Account-ID]/GuardDuty/[Region]/` if not provided. | `string` | `""` | no |
 | <a name="input_scan_eks_audit_logs"></a> [scan\_eks\_audit\_logs](#input\_scan\_eks\_audit\_logs) | (Optional) If true, enables Kubernetes audit logs as a data source for Kubernetes protection. Defaults to `true`. | `bool` | `true` | no |
@@ -94,3 +95,4 @@ Checkout our other :point\_right: [terraform modules](https://registry.terraform
 ## Copyright
 
 Copyright © 2017-2025 [Blackbird Cloud](https://blackbird.cloud)
+<!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -124,4 +124,10 @@ resource "aws_guardduty_member" "members" {
   email              = each.value.email
   invite             = true
   invitation_message = "please accept guardduty invitation"
+
+  lifecycle {
+    ignore_changes = [
+      email
+    ]
+  }
 }


### PR DESCRIPTION
## What
* Added a lifecycle on aws_guardduty_member to ignore email changes

## Why
* It always changes, and when you re-run the terraform it wants to recreate all invites

